### PR TITLE
healthd: Turn screen off before rebooting

### DIFF
--- a/healthd/healthd_mode_charger.cpp
+++ b/healthd/healthd_mode_charger.cpp
@@ -733,6 +733,8 @@ static void process_key(struct charger *charger, int code, int64_t now)
                    accordingly. */
                 if (property_get_bool("ro.enable_boot_charger_mode", false)) {
                     LOGW("[%" PRId64 "] booting from charger mode\n", now);
+                    set_backlight(false);
+                    gr_fb_blank(true);
                     property_set("sys.boot_from_charger_mode", "1");
                 } else {
                     LOGW("[%" PRId64 "] rebooting\n", now);


### PR DESCRIPTION
Some hardware doesn't like being rebooted with the panel on
and active.  This resolves panel corruption in some such cases.

Change-Id: I7f00ee70a4ce2db9c362e319b844b798d7cb2910
